### PR TITLE
feat(client): add publish_tombstone for clearing retained topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to franzmq are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **`Client.publish_tombstone(topic, qos=0)`** -- publish an empty retained payload to clear a previously retained topic. Always sends `retain=True`. Use this to retract a retained `Payload` from the broker, e.g. when deleting an asset whose state was kept under a retained topic. Previously, calling `publish(topic, None)` crashed with `AttributeError: 'NoneType' object has no attribute 'encode'`.
+
 ## [0.4.0] - 2026-02-22
 
 ### Breaking Changes

--- a/src/franzmq/client.py
+++ b/src/franzmq/client.py
@@ -85,6 +85,16 @@ class Client(PahoClient):
     def publish(self, topic: Topic, payload: Payload, qos=0, retain=False):
         super().publish(str(topic), payload.encode(), qos, retain)
 
+    def publish_tombstone(self, topic: Topic, qos: int = 0):
+        """Publish an empty retained payload to clear a retained topic.
+
+        MQTT brokers remove a topic's retained message when they receive an
+        empty payload on it. Use this to retract a previously retained
+        ``Payload``. Always sends ``retain=True`` because tombstones only make
+        sense against retained topics.
+        """
+        super().publish(str(topic), b"", qos, retain=True)
+
     def subscribe(self, topic: Topic | str, qos: int = 0, callback=None, priority: int = 0):
         """
         Subscribe to a topic and (optionally) register a callback with an optional priority.

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,49 @@
+"""Unit tests for franzmq.Client.publish and publish_tombstone."""
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from paho.mqtt.client import Client as PahoClient
+
+from franzmq.client import Client
+from franzmq.data_contracts.base import Payload
+from franzmq.topic import Topic
+
+
+@dataclass
+class _DummyPayload(Payload):
+    value: int = 0
+
+
+def _topic() -> Topic:
+    return Topic(payload_type=_DummyPayload, context=("a", "b"))
+
+
+def test_publish_encodes_payload():
+    client = Client()
+    with patch.object(PahoClient, "publish") as mock_publish:
+        client.publish(_topic(), _DummyPayload(value=7))
+    mock_publish.assert_called_once()
+    args, _ = mock_publish.call_args
+    assert args[1] == _DummyPayload(value=7).encode()
+    assert args[2] == 0
+    assert args[3] is False
+
+
+def test_publish_tombstone_sends_empty_retained_payload():
+    client = Client()
+    with patch.object(PahoClient, "publish") as mock_publish:
+        client.publish_tombstone(_topic())
+    mock_publish.assert_called_once()
+    args, kwargs = mock_publish.call_args
+    assert args[1] == b""
+    assert args[2] == 0
+    assert kwargs.get("retain", args[3] if len(args) > 3 else None) is True
+
+
+def test_publish_tombstone_passes_custom_qos():
+    client = Client()
+    with patch.object(PahoClient, "publish") as mock_publish:
+        client.publish_tombstone(_topic(), qos=1)
+    args, kwargs = mock_publish.call_args
+    assert args[2] == 1
+    assert kwargs.get("retain", args[3] if len(args) > 3 else None) is True


### PR DESCRIPTION
## Summary

Calling `Client.publish(topic, None)` previously crashed with `AttributeError: 'NoneType' object has no attribute 'encode'`. Tombstoning a retained topic — publishing an empty payload with `retain=True` to retract it — is a valid MQTT operation that franzmq did not expose cleanly.

This PR adds a dedicated `Client.publish_tombstone(topic, qos=0)` method that always sends `b\"\"` with `retain=True`.

- `publish()` keeps its typed-`Payload` signature unchanged → contract discipline stays intact at call sites.
- Tombstoning is now explicit at the call site (no accidental `retain=False` tombstones, no overloaded `None` handling).
- Real-world driver: PREKIT needs to retract retained \`SystemElement\` / \`Signal\` topics when assets are deleted. Today it uses paho-mqtt directly as a workaround.

## Test plan

- [x] \`tests/test_publish.py::test_publish_encodes_payload\` — existing behavior unchanged
- [x] \`tests/test_publish.py::test_publish_tombstone_sends_empty_retained_payload\` — empty payload, retain=True
- [x] \`tests/test_publish.py::test_publish_tombstone_passes_custom_qos\` — qos parameter forwarded
- [x] All 3 pass locally (\`python -m pytest tests/test_publish.py -v\`)
- [x] Reviewer: confirm naming / behavior fits franzmq's typed-contract design ethos